### PR TITLE
README.md: fix code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ routes =
 index :: ResponderM a
 index = send $ html "Hello World!"
 
-echo :: ResponderM a
-echo = do
+echoName :: ResponderM a
+echoName = do
   name <- param "name"
   send $ html $ "Hello, " <> name
 


### PR DESCRIPTION
It doesn't look like the old example would have worked since `echoName` does not exist (unless I am missing something).