### PR TITLE
Bump transformers upper bounds for ghc-9.6

### DIFF
--- a/twain.cabal
+++ b/twain.cabal
@@ -47,7 +47,7 @@ library
     , http2 >=1.0.0 && <3.3.0
     , text >=1.2.3 && <3
     , time >=1.8 && <2
-    , transformers >=0.5.6 && <0.6
+    , transformers >=0.5.6 && <0.7
     , vault ==0.3.*
     , wai ==3.2.*
     , wai-extra >=3.0 && <3.2


### PR DESCRIPTION
The version of the transformers library [released with ghc 9.6.1](https://downloads.haskell.org/ghc/latest/docs/users_guide/9.6.1-notes.html#included-libraries) is 0.6.1.0. This PR bumps the upper bounds of the transformer package so twain can be built with ghc 9.6.1.