### PR TITLE
Fix Data.Text imports and related references

### DIFF
--- a/src/Web/Twain.hs
+++ b/src/Web/Twain.hs
@@ -114,7 +114,8 @@ import qualified Data.CaseInsensitive as CI
 import Data.Either.Combinators (rightToMaybe)
 import qualified Data.List as L
 import Data.Maybe (fromMaybe)
-import Data.Text as T
+import Data.Text (Text)
+import qualified Data.Text as T
 import Data.Text.Encoding
 import Data.Time
 import qualified Data.Vault.Lazy as V

--- a/src/Web/Twain/Internal.hs
+++ b/src/Web/Twain/Internal.hs
@@ -11,7 +11,7 @@ import qualified Data.ByteString.Lazy as BL
 import Data.Int
 import Data.List as L
 import Data.Maybe (fromMaybe)
-import Data.Text as T
+import qualified Data.Text as T
 import Data.Text.Encoding
 import qualified Data.Vault.Lazy as V
 import Data.Word (Word64)
@@ -121,7 +121,7 @@ wrapParseErr (HTTP2Exception (ErrorCode code)) = do
   let statusCode = fromIntegral code
       statusMsg = BC.pack $ "HTTP/2 error: " ++ show code
       status = mkStatus statusCode statusMsg
-      errorMsg = unpack $ decodeUtf8 statusMsg
+      errorMsg = T.unpack $ decodeUtf8 statusMsg
   throwIO $ HttpError status errorMsg
 
 


### PR DESCRIPTION
Twain 2.2.0.0 does not compile due to way of Data.Text imported in `Twain.hs`
and in `Twain/Internal.hs`.

For example:
```
src/Web/Twain/Internal.hs:116:41: error: [GHC-87543]
    Ambiguous occurrence ‘show’.
    It could refer to
       either ‘Prelude.show’,
              imported from ‘Prelude’ at src/Web/Twain/Internal.hs:1:8-25
              (and originally defined in ‘ghc-internal-9.1001.0:GHC.Internal.Show’),
           or ‘T.show’,
              imported from ‘Data.Text’ at src/Web/Twain/Internal.hs:14:1-21.
    |
116 |     "Request body size larger than " <> show max <> " bytes."
    |                                         ^^^^

```

This PR fixes these problems, so the whole package can be compiled.
