### PR TITLE
Removes uneeded dependencies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.2.0.2 [2025-08-28]
+- Remove unneeded packages
+  - transformers: not used at all
+  - either: has a lot of dependencies for just the two used functions (mapRight and rightToMaybe)
+- Move common cabal configuration to a shared stanza
+
 ## 2.2.0.1 [2024-11-05]
 
 - Fix failing compilation: Use qualified import of Data.Text.

--- a/src/Web/Twain.hs
+++ b/src/Web/Twain.hs
@@ -111,7 +111,6 @@ import qualified Data.Aeson as JSON
 import Data.ByteString.Char8 as Char8
 import Data.ByteString.Lazy as BL
 import qualified Data.CaseInsensitive as CI
-import Data.Either.Combinators (rightToMaybe)
 import qualified Data.List as L
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -124,7 +123,6 @@ import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Parse hiding (Param)
 import Network.Wai.Request
-import System.Environment (lookupEnv)
 import Web.Cookie
 import Web.Twain.Internal
 import Web.Twain.Types
@@ -502,3 +500,6 @@ redirect302 url = raw status302 [(hLocation, encodeUtf8 url)] ""
 -- | Create a redirect response 303 status (See Other).
 redirect303 :: Text -> Response
 redirect303 url = raw status303 [(hLocation, encodeUtf8 url)] ""
+
+rightToMaybe :: Either e a -> Maybe a
+rightToMaybe = either (const Nothing) Just

--- a/test/TwainSpec.hs
+++ b/test/TwainSpec.hs
@@ -1,11 +1,10 @@
 module TwainSpec where
 
-import Web.Twain
 import Control.Monad (when)
-import Control.Monad.IO.Class (liftIO)
 import Data.String (fromString)
 import Test.Hspec
 import qualified Test.Hspec.Wai as Test
+import Web.Twain
 
 -- * Tests
 
@@ -17,8 +16,8 @@ spec = Test.with (pure app) $ do
         Test.shouldRespondWith
           (Test.get "/")
           "Hello World!"
-            { Test.matchStatus = 200
-            , Test.matchHeaders = ["Content-Type" Test.<:> "text/html; charset=utf-8"]
+            { Test.matchStatus = 200,
+              Test.matchHeaders = ["Content-Type" Test.<:> "text/html; charset=utf-8"]
             }
 
     describe "GET /json" $ do
@@ -26,8 +25,8 @@ spec = Test.with (pure app) $ do
         Test.shouldRespondWith
           (Test.get "/json")
           "[true]"
-            { Test.matchStatus = 200
-            , Test.matchHeaders = ["Content-Type" Test.<:> "application/json; charset=utf-8"]
+            { Test.matchStatus = 200,
+              Test.matchHeaders = ["Content-Type" Test.<:> "application/json; charset=utf-8"]
             }
 
     describe "GET /css" $ do
@@ -35,33 +34,33 @@ spec = Test.with (pure app) $ do
         Test.shouldRespondWith
           (Test.get "/css")
           (fromString style)
-            { Test.matchStatus = 200
-            , Test.matchHeaders = ["Content-Type" Test.<:> "text/css; charset=utf-8"]
+            { Test.matchStatus = 200,
+              Test.matchHeaders = ["Content-Type" Test.<:> "text/css; charset=utf-8"]
             }
 
     describe "GET /notfound" $ do
       it "responds with 404 / 'Not found...'" $
         Test.shouldRespondWith
           (Test.get "/notfound")
-          "Not found..." { Test.matchStatus = 404 }
+          "Not found..." {Test.matchStatus = 404}
 
   describe "POST" $ do
     describe "POST /echo/James" $ do
       it "Without body - responds with 200 & 'Hello, James'" $
         Test.shouldRespondWith
           (Test.post "/echo/James" "")
-          "Hello, James" { Test.matchStatus = 200 }
+          "Hello, James" {Test.matchStatus = 200}
 
       it "With body - responds with 200 & 'Hello, Jameson'" $
         Test.shouldRespondWith
           (Test.postHtmlForm "/echo/James" [("bodyname", "Jameson")])
-          "Hello, Jameson" { Test.matchStatus = 200 }
+          "Hello, Jameson" {Test.matchStatus = 200}
 
     describe "POST /echo/" $ do
       it "responds with 404 & 'Person not specified...' (next works correctly)" $
         Test.shouldRespondWith
           (Test.postHtmlForm "/echo/" [])
-          "Person not specified..." { Test.matchStatus = 404 }
+          "Person not specified..." {Test.matchStatus = 404}
 
 -- * App
 
@@ -70,11 +69,11 @@ app = foldr ($) (notFound missing) routes
 
 routes :: [Middleware]
 routes =
-  [ get "/" index
-  , get "/json" myjson
-  , get "/css" (send $ css $ fromString style)
-  , post "/echo/:name" echo
-  , post "/echo/:name" missingPerson
+  [ get "/" index,
+    get "/json" myjson,
+    get "/css" (send $ css $ fromString style),
+    post "/echo/:name" echo,
+    post "/echo/:name" missingPerson
   ]
 
 index :: ResponderM a
@@ -89,7 +88,7 @@ style = "body { width: 900px; margin: auto; }"
 echo :: ResponderM a
 echo = do
   name <- fmap (unwords . words) $ paramMaybe "bodyname" >>= maybe (param "name") pure
-  when (null name) $ next
+  when (null name) next
   send $ html $ "Hello, " <> fromString name
 
 missing :: ResponderM a
@@ -98,5 +97,7 @@ missing = send $ html "Not found..."
 missingPerson :: ResponderM a
 missingPerson =
   send $
-    raw status404 [("Content-Type", "text/html; charset=utf-8")] $
+    raw
+      status404
+      [("Content-Type", "text/html; charset=utf-8")]
       "Person not specified..."

--- a/twain.cabal
+++ b/twain.cabal
@@ -72,7 +72,6 @@ test-suite twain-test
     TwainSpec
   build-depends:
     hspec
-    , hspec-discover
     , hspec-wai
     , twain
   ghc-options:

--- a/twain.cabal
+++ b/twain.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.2
 -- see: https://github.com/sol/hpack
 
 name:           twain
-version:        2.2.0.1
+version:        2.2.0.2
 synopsis:       Tiny web application framework for WAI.
 description:    Twain is tiny web application framework for WAI. It provides routing, parameter parsing, and an either-like monad for composing responses.
 category:       Web

--- a/twain.cabal
+++ b/twain.cabal
@@ -25,7 +25,23 @@ source-repository head
   type: git
   location: https://github.com/alexmingoia/twain
 
+common shared
+    ghc-options:
+      -Wall
+      -Wunused-packages
+      -Widentities
+      -Wincomplete-record-updates
+      -Wincomplete-uni-patterns
+      -Wpartial-fields
+      -Wredundant-constraints
+    build-depends:
+      base >=4.7 && <5
+    default-language: Haskell2010
+    default-extensions:
+      OverloadedStrings
+
 library
+  import: shared
   exposed-modules:
     Web.Twain
     Web.Twain.Types
@@ -33,37 +49,29 @@ library
     Web.Twain.Internal
   hs-source-dirs:
     src
-  default-extensions:
-    OverloadedStrings
   build-depends:
       aeson >=2 && <3
-    , base >=4.7 && <5
     , bytestring >=0.10 && < 0.12
     , case-insensitive ==1.2.*
     , cookie >=0.4 && <0.6
-    , either ==5.0.*
     , exceptions ==0.10.*
     , http-types ==0.12.*
     , http2 >=5.0 && <5.4
     , text >=1.2.3 && <3
     , time >=1.8 && <2
-    , transformers >=0.5.6 && <0.7
     , vault ==0.3.*
     , wai ==3.2.*
     , wai-extra >=3.0 && <3.2
-  default-language: Haskell2010
 
 test-suite twain-test
+  import: shared
   type: exitcode-stdio-1.0
   hs-source-dirs: test
   main-is: Spec.hs
   other-modules:
     TwainSpec
-  default-extensions:
-    OverloadedStrings
   build-depends:
-      base
-    , hspec
+    hspec
     , hspec-discover
     , hspec-wai
     , twain
@@ -71,4 +79,3 @@ test-suite twain-test
     -threaded -rtsopts -with-rtsopts=-N
   build-tool-depends:
     hspec-discover:hspec-discover
-  default-language: Haskell2010


### PR DESCRIPTION
This patch is mainly focused on cleanup.

1. Removes the `either` package, this package have many dependencies that aren't needed for twain, which uses only two combinators:
 
```haskell
rightToMaybe :: Either a b -> Maybe b
rightToMaybe = either (const Nothing) Just

-- and

mapRight :: (b -> c) -> Either a b -> Either a c
mapRight = second
```
both can easily be implemented using only base.

2. Building with warnings enabled showed that the package `transformers` wasn't used at all, so it was removed.
3. Turns on some useful warnings
4. Applies hlint suggestions (removes redundant imports, sorts imports, change some datatypes to newtypes)
5. Formats with ormolu